### PR TITLE
Add proxy class and interface to hide Symfony component

### DIFF
--- a/src/Convo/Core/ConvoServiceInstance.php
+++ b/src/Convo/Core/ConvoServiceInstance.php
@@ -129,7 +129,7 @@ class ConvoServiceInstance implements \Convo\Core\Workflow\IWorkflowContainerCom
 
     public function __construct(
         \Psr\Log\LoggerInterface $logger,
-        \Convo\Core\EvaluationContext $eval,
+        \Convo\Core\Eval\EvaluationContext $eval,
         \Convo\Core\Params\IServiceParamsFactory $paramsFactory,
         \Convo\Core\IAdminUser $user,
         $serviceId

--- a/src/Convo/Core/Eval/EvaluationContext.php
+++ b/src/Convo/Core/Eval/EvaluationContext.php
@@ -1,9 +1,9 @@
 <?php declare(strict_types=1);
 
-namespace Convo\Core;
+namespace Convo\Core\Eval;
 
 use Zef\Zel\Symfony\ExpressionLanguage;
-use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Convo\Core\Eval\ExpressionFunctionProviderInterface;
 
 class EvaluationContext
 {

--- a/src/Convo/Core/Eval/ExpressionFunction.php
+++ b/src/Convo/Core/Eval/ExpressionFunction.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+namespace Convo\Core\Eval;
+
+class ExpressionFunction extends \Symfony\Component\ExpressionLanguage\ExpressionFunction {}

--- a/src/Convo/Core/Eval/ExpressionFunctionProviderInterface.php
+++ b/src/Convo/Core/Eval/ExpressionFunctionProviderInterface.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+namespace Convo\Core\Eval;
+
+interface ExpressionFunctionProviderInterface extends \Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface {}

--- a/src/Convo/Core/Factory/AbstractPackageDefinition.php
+++ b/src/Convo/Core/Factory/AbstractPackageDefinition.php
@@ -8,7 +8,7 @@ use Convo\Core\Intent\ISystemEntityRepository;
 use Convo\Core\Intent\ISystemIntentRepository;
 use Convo\Core\Intent\SystemEntity;
 use Convo\Core\Intent\SystemIntent;
-use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Convo\Core\Eval\ExpressionFunctionProviderInterface;
 
 abstract class AbstractPackageDefinition
     implements

--- a/src/Convo/Core/Factory/ConvoServiceFactory.php
+++ b/src/Convo/Core/Factory/ConvoServiceFactory.php
@@ -53,7 +53,7 @@ class ConvoServiceFactory
 		$this->_logger->debug( 'Data loaded');
 
         $provider = $this->_packageProviderFactory->getProviderFromPackageIds($data['packages']);
-        $eval = new \Convo\Core\EvaluationContext($this->_logger, $provider);
+        $eval = new \Convo\Core\Eval\EvaluationContext($this->_logger, $provider);
 
 		$service	=	new \Convo\Core\ConvoServiceInstance(
 			$this->_logger,

--- a/src/Convo/Core/Factory/PackageProvider.php
+++ b/src/Convo/Core/Factory/PackageProvider.php
@@ -3,7 +3,7 @@
 namespace Convo\Core\Factory;
 
 use Convo\Core\Rest\NotFoundException;
-use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Convo\Core\Eval\ExpressionFunctionProviderInterface;
 
 class PackageProvider implements
     \Convo\Core\Intent\ISystemIntentRepository,

--- a/tests/unit/Convo/Core/EvaluationContextTest.php
+++ b/tests/unit/Convo/Core/EvaluationContextTest.php
@@ -1,13 +1,13 @@
 <?php declare(strict_types=1);
 
-use Convo\Core\EvaluationContext;
+use Convo\Core\Eval\EvaluationContext;
 use Convo\Core\Params\SimpleParams;
 use Convo\Core\Util\ArrayUtil;
 use PHPUnit\Framework\TestCase;
 use Convo\Core\Util\EchoLogger;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\ExpressionLanguage\ExpressionFunction;
-use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Convo\Core\Eval\ExpressionFunction;
+use Convo\Core\Eval\ExpressionFunctionProviderInterface;
 use Zef\Zel\ArrayResolver;
 use Zef\Zel\ObjectResolver;
 


### PR DESCRIPTION
Add a proxy class for Symfony's `ExpressionFunction` and a proxy interface for `ExpressionFunctionProviderInterface`