### PR TITLE
New element - Element Queue

### DIFF
--- a/src/Convo/Pckg/Core/CorePackageDefinition.php
+++ b/src/Convo/Pckg/Core/CorePackageDefinition.php
@@ -1455,8 +1455,7 @@ class CorePackageDefinition extends AbstractPackageDefinition
                     'scope_type' => array(
                         'editor_type' => 'select',
                         'editor_properties' => array(
-                            'options' => array('session' => 'Session', 'installation' => 'Installation', 'user' => 'User'),
-                            'dependency' => 'component.properties.should_reset === false'
+                            'options' => array('session' => 'Session', 'installation' => 'Installation', 'user' => 'User')
                         ),
                         'defaultValue' => 'session',
                         'name' => 'Scope type',

--- a/src/Convo/Pckg/Core/CorePackageDefinition.php
+++ b/src/Convo/Pckg/Core/CorePackageDefinition.php
@@ -1448,6 +1448,62 @@ class CorePackageDefinition extends AbstractPackageDefinition
             ),
             new \Convo\Core\Factory\ComponentDefinition(
                 $this->getNamespace(),
+                '\Convo\Pckg\Core\Elements\ElementQueue',
+                'Element Queue',
+                'Execute elements in sequence, with an optional flow to read if all elements have been executed',
+                array(
+                    'scope_type' => array(
+                        'editor_type' => 'select',
+                        'editor_properties' => array(
+                            'options' => array('session' => 'Session', 'installation' => 'Installation', 'user' => 'User'),
+                            'dependency' => 'component.properties.should_reset === false'
+                        ),
+                        'defaultValue' => 'session',
+                        'name' => 'Scope type',
+                        'description' => 'Sets when to run elements in sequence.',
+                        'valueType' => 'string'
+                    ),
+                    'elements' => array(
+                        'editor_type' => 'service_components',
+                        'editor_properties' => array(
+                            'allow_interfaces' => array('\Convo\Core\Workflow\IConversationElement'),
+                            'multiple' => true
+                        ),
+                        'defaultValue' => array(),
+                        'defaultOpen' => true,
+                        'name' => 'Elements',
+                        'description' => 'Elements to be executed in order',
+                        'valueType' => 'class'
+                    ),
+                    'done' => array(
+                        'editor_type' => 'service_components',
+                        'editor_properties' => array(
+                            'allow_interfaces' => array('\Convo\Core\Workflow\IConversationElement'),
+                            'multiple' => true
+                        ),
+                        'defaultValue' => array(),
+                        'defaultOpen' => true,
+                        'name' => 'Done',
+                        'description' => 'Elements to be executed if main flow has been executed already.',
+                        'valueType' => 'class'
+                    ),
+					'should_reset' => array(
+						'editor_type' => 'boolean',
+						'editor_properties' => array(),
+						'defaultValue' => false,
+						'name' => 'Should Reset',
+						'description' => 'Toggle whether to read the "Done" flow once elements have been read in sequence, or to start over.',
+						'valueType' => 'boolean'
+					),
+                    '_help' =>  array(
+                        'type' => 'file',
+                        'filename' => 'element-queue.html'
+                    ),
+                    '_workflow' => 'read',
+                )
+            ),
+            new \Convo\Core\Factory\ComponentDefinition(
+                $this->getNamespace(),
                 '\Convo\Pckg\Core\Elements\CardElement',
                 'x!Card',
                 'Display the properties of an object in an visual layout. (Works with devices that have the screen output capability.)',

--- a/src/Convo/Pckg/Core/Elements/ElementQueue.php
+++ b/src/Convo/Pckg/Core/Elements/ElementQueue.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Convo\Pckg\Core\Elements;
+
+use Convo\Core\Workflow\AbstractWorkflowContainerComponent;
+use Convo\Core\Workflow\IConversationElement;
+use Convo\Core\Workflow\IConvoRequest;
+use Convo\Core\Workflow\IConvoResponse;
+
+class ElementQueue extends AbstractWorkflowContainerComponent implements IConversationElement
+{
+    private $_scopeType;
+
+    /**
+     * @var IConversationElement[]
+     */
+    private $_elements;
+
+    /**
+     * @var IConversationElement[]
+     */
+    private $_done;
+
+    private $_shouldReset;
+
+    public function __construct($properties)
+    {
+        parent::__construct($properties);
+
+        $this->_scopeType = $properties['scope_type'];
+
+        $this->_shouldReset = $properties['should_reset'];
+
+        $this->_elements = $properties['elements'] ?: [];
+
+        foreach ($this->_elements as $element) {
+            $this->addChild($element);
+            $element->setParent($this);
+        }
+
+        $this->_done = $properties['done'] ?: [];
+
+        foreach ($this->_done as $done) {
+            $this->addChild($done);
+            $done->setParent($this);
+        }
+    }
+    public function read(IConvoRequest $request, IConvoResponse $response)
+    {
+        $params = $this->getService()->getComponentParams($this->evaluateString($this->_scopeType), $this);
+        $ran = $params->getServiceParam('triggered');
+
+        if ($ran)
+        {
+            $should_reset = $this->evaluateString($this->_shouldReset);
+            $this->_logger->info('Element queue already ran its elements, and should_reset flag is set to ['.$should_reset ? 'true' : 'false'.']');
+
+            if ($should_reset)
+            {
+                $this->_logger->info('Re-reading element queue.');
+
+                foreach ($this->_elements as $element)
+                {
+                    $element->read($request, $response);
+                }
+            }
+            else
+            {
+                $this->_logger->info('Going to read done flow, if any.');
+                foreach ($this->_done as $done)
+                {
+                    $done->read($request, $response);
+                }
+            }
+        }
+        else
+        {
+            $this->_logger->info('Queue has not yet been executed, reading elements.');
+
+            foreach ($this->_elements as $element)
+            {
+                $element->read($request, $response);
+            }
+
+            $params->setServiceParam('triggered', true);
+        }
+    }
+}

--- a/src/Convo/Pckg/Core/Help/element-queue.html
+++ b/src/Convo/Pckg/Core/Help/element-queue.html
@@ -1,12 +1,13 @@
 <div class="element-queue-help">
     <h3>Element Queue</h3>
-    <p>This element executes its child elements in sequence. You can decide how often it will check if they've been executed, i.e. once per request, session, or installation.</p>
+    <p>This element executes its child elements in sequence, one by one, each time it's called. You can decide how often it will check if its child elements have been executed, i.e. once per request, session, or installation.</p>
     <p>Optionally, you may also put elements in a "Done" flow that will run if the Queue element is read again, but has already executed its elements in the given scope.</p>
-    <p>You can also set the element to always re-read its children, without checking if it's been run already.</p>
+    <p>You can also set the Queue to always re-read its children, without checking if it's been run already, by setting the <code>Should Reset</code> property to true.</p>
+    <p>The <b>Element Queue</b> is similar to the <b>Element Randomizer</b>, difference being that the Queue executes its elements sequentially.</p>
 
     <h4>When to use?</h4>
 
-    <p>When you have elements you wish to run in sequence, while having control over how often they run, and with an additional flow in case they've been executed.</p>
+    <p>When you have elements you wish to run in sequence, one by one, while having control over how often they run, and with an additional flow in case they've been executed.</p>
 
     <h4>How to use?</h4>
 

--- a/src/Convo/Pckg/Core/Help/element-queue.html
+++ b/src/Convo/Pckg/Core/Help/element-queue.html
@@ -1,0 +1,19 @@
+<div class="element-queue-help">
+    <h3>Element Queue</h3>
+    <p>This element executes its child elements in sequence. You can decide how often it will check if they've been executed, i.e. once per request, session, or installation.</p>
+    <p>Optionally, you may also put elements in a "Done" flow that will run if the Queue element is read again, but has already executed its elements in the given scope.</p>
+    <p>You can also set the element to always re-read its children, without checking if it's been run already.</p>
+
+    <h4>When to use?</h4>
+
+    <p>When you have elements you wish to run in sequence, while having control over how often they run, and with an additional flow in case they've been executed.</p>
+
+    <h4>How to use?</h4>
+
+    <ul>
+        <li>Place whichever children elements you wish to execute in sequence in the <code>Elements</code> flow.</li>
+        <li>Optionally, you may also add child elements to the <code>Done</code> flow which will run if the Queue element is read again, but has already executed its children.</li>
+        <li>The <code>Should reset</code> property dictates whether or not to execute the <code>Done</code> flow once the queue has been executed, or to re-read the queue again.</li>
+        <li><code>Scope type</code> governs how "often" the queue will run, if <code>Should reset</code> is toggled off. This essentially means, "read the queue once per installation/session/request".</li>
+    </ul>
+</div>


### PR DESCRIPTION
* This element has two flows: "Elements" and "Done"
* Similar to `ElementRandomizer`, it will execute its child elements one by one, this time in an ordered queue
* How often elements are checked for having been executed is dictated by the `scope_type` property
* The optional `done` flow runs if all the child elements have been read
* Toggling the `should_reset` property to true will re-run child elements after the last one has been executed
