### PR TITLE
Required slots now have a special editor type

### DIFF
--- a/src/Convo/Pckg/Core/CorePackageDefinition.php
+++ b/src/Convo/Pckg/Core/CorePackageDefinition.php
@@ -1209,14 +1209,12 @@ class CorePackageDefinition extends AbstractPackageDefinition
                         'valueType' => 'string'
                     ),
                     'required_slots' => array(
-                        'editor_type' => 'text',
-                        'editor_properties' => array(
-                            'multiple' => false
-                        ),
+                        'editor_type' => 'required_slots',
+                        'editor_properties' => array(),
                         'defaultValue' => '',
                         'name' => 'Required slots',
-                        'description' => 'List of required slot names (comma separated). If required slot is empty, filter will not activate even if intent name is correct.',
-                        'valueType' => 'string'
+                        'description' => 'List of slots, their types, and whether or not any of them are absolutely required for the reader to trigger.',
+                        'valueType' => 'array'
                     ),
                     'values' => array(
                         'editor_type' => 'params',

--- a/src/Convo/Pckg/Core/Filters/ConvoIntentReader.php
+++ b/src/Convo/Pckg/Core/Filters/ConvoIntentReader.php
@@ -23,21 +23,7 @@ class ConvoIntentReader extends PlatformIntentReader implements \Convo\Core\Inte
         $this->_packageProviderFactory  =   $packageProviderFactory;
         $this->_disable = $config['disable'] ?? false;
 
-        if (isset($config['required_slots']) && $config['required_slots'] !== '')
-        {
-            $parts = explode(',', $config['required_slots']);
-
-            if (count($parts) === 1 && empty($parts[0]))
-            {
-                $this->_logger->warning('Exploded empty string and got one empty element.');
-                return;
-            }
-
-            $this->_requiredSlots = array_map(
-                function($slot) { return trim($slot); },
-                $parts
-            );
-        }
+        $this->_requiredSlots = $config['required_slots'] ?: [];
     }
 
     public function accepts(IIntentAwareRequest $request)


### PR DESCRIPTION
* Use new `required_slots` editor type for required slots
* Simplify having to manually split and clean required slots from string input