### PR TITLE
Add remove child capability

### DIFF
--- a/src/Convo/Core/ConvoServiceInstance.php
+++ b/src/Convo/Core/ConvoServiceInstance.php
@@ -867,21 +867,9 @@ class ConvoServiceInstance implements \Convo\Core\Workflow\IWorkflowContainerCom
 
     public function removeChild(IBasicServiceComponent $child)
 	{
-		$index_to_remove = -1;
-
-		foreach ($this->_children as $index => $c) {
-            echo 'Currently checking removal ID ['.$child->getId().'] against child ['.$c->getId().']'.PHP_EOL;
-			if ($child->getId() === $c->getId()) {
-				$index_to_remove = $index;
-				break;
-			}
-		}
-
-		if ($index_to_remove === -1) {
-			throw new \Exception('Child element ['.$child.'] could not be found inside parent element ['.$this.']');
-		}
-
-		\array_splice($this->_children, $index_to_remove, 1);
+        $this->_children = \array_filter($this->_children, function ($c) use ($child) {
+            return $c->getId() !== $child->getId();
+        });
 	}
 
     /**

--- a/src/Convo/Core/ConvoServiceInstance.php
+++ b/src/Convo/Core/ConvoServiceInstance.php
@@ -857,7 +857,6 @@ class ConvoServiceInstance implements \Convo\Core\Workflow\IWorkflowContainerCom
                     $parent->removeChild($child);
                 }
             } catch (ComponentNotFoundException $e) {
-                $this->_logger->info($e->getMessage());
             } finally {
                 $child->setParent( $this);
             }

--- a/src/Convo/Core/ConvoServiceInstance.php
+++ b/src/Convo/Core/ConvoServiceInstance.php
@@ -854,7 +854,7 @@ class ConvoServiceInstance implements \Convo\Core\Workflow\IWorkflowContainerCom
                 $parent = $child->getParent();
                 
                 if ($parent !== $this) {
-                    $child->getParent()->removeChild($child);
+                    $parent->removeChild($child);
                 }
             } catch (ComponentNotFoundException $e) {
                 $this->_logger->info($e->getMessage());

--- a/src/Convo/Core/Workflow/AbstractWorkflowComponent.php
+++ b/src/Convo/Core/Workflow/AbstractWorkflowComponent.php
@@ -27,7 +27,7 @@ abstract class AbstractWorkflowComponent extends AbstractBasicComponent implemen
 	 */
 	public function getParent() {
 		if ( !$this->_parent) {
-			throw new \Convo\Core\ComponentNotFoundException( 'Parent not set in ['.get_class($this).']['.$this->getId().']');
+			throw new \Convo\Core\ComponentNotFoundException( 'Parent not set in ['.$this.']');
 		}
 		return $this->_parent;
 	}

--- a/src/Convo/Core/Workflow/AbstractWorkflowComponent.php
+++ b/src/Convo/Core/Workflow/AbstractWorkflowComponent.php
@@ -27,7 +27,7 @@ abstract class AbstractWorkflowComponent extends AbstractBasicComponent implemen
 	 */
 	public function getParent() {
 		if ( !$this->_parent) {
-			throw new \Convo\Core\ComponentNotFoundException( 'Parent not set in ['.$this.']');
+			throw new \Convo\Core\ComponentNotFoundException( 'Parent not set in ['.get_class($this).']['.$this->getId().']');
 		}
 		return $this->_parent;
 	}

--- a/src/Convo/Core/Workflow/AbstractWorkflowContainerComponent.php
+++ b/src/Convo/Core/Workflow/AbstractWorkflowContainerComponent.php
@@ -44,7 +44,6 @@ abstract class AbstractWorkflowContainerComponent extends AbstractWorkflowCompon
                     $parent->removeChild($child);
                 }
             } catch (ComponentNotFoundException $e) {
-                $this->_logger->info($e->getMessage());
             } finally {
 				$child->setParent( $this);
 			}

--- a/src/Convo/Core/Workflow/AbstractWorkflowContainerComponent.php
+++ b/src/Convo/Core/Workflow/AbstractWorkflowContainerComponent.php
@@ -11,7 +11,7 @@ abstract class AbstractWorkflowContainerComponent extends AbstractWorkflowCompon
 {
 	
 	/**
-	 * @var \Convo\Core\Workflow\IBasicServiceComponent
+	 * @var \Convo\Core\Workflow\IBasicServiceComponent[]
 	 */
 	private $_children	=	array();
 	

--- a/src/Convo/Core/Workflow/AbstractWorkflowContainerComponent.php
+++ b/src/Convo/Core/Workflow/AbstractWorkflowContainerComponent.php
@@ -52,20 +52,9 @@ abstract class AbstractWorkflowContainerComponent extends AbstractWorkflowCompon
 
 	public function removeChild(IBasicServiceComponent $child)
 	{
-		$index_to_remove = -1;
-
-		foreach ($this->_children as $index => $c) {
-			if ($child->getId() === $c->getId()) {
-				$index_to_remove = $index;
-				break;
-			}
-		}
-
-		if ($index_to_remove === -1) {
-			throw new \Exception('Child element ['.$child.'] could not be found inside parent element ['.$this.']');
-		}
-
-		\array_splice($this->_children, $index_to_remove, 1);
+		$this->_children = \array_filter($this->_children, function ($c) use ($child) {
+            return $c->getId() !== $child->getId();
+        });
 	}
 	
 	/**

--- a/src/Convo/Core/Workflow/IWorkflowContainerComponent.php
+++ b/src/Convo/Core/Workflow/IWorkflowContainerComponent.php
@@ -17,6 +17,13 @@ interface IWorkflowContainerComponent extends \Convo\Core\Workflow\IServiceWorkf
 	public function addChild(\Convo\Core\Workflow\IBasicServiceComponent $child);
 
 	/**
+	 * Removes the given child component from the parent. Implement it such that the parent is removed from the child only if the child is
+	 * an instance of IServiceWorkflowComponent
+	 * @param \Convo\Core\Workflow\IBasicServiceComponent $child
+	 */
+	public function removeChild(\Convo\Core\Workflow\IBasicServiceComponent $child);
+
+	/**
 	 * Returns direct component children.
 	 * @return \Convo\Core\Workflow\IBasicServiceComponent[]
 	 */

--- a/src/Convo/Pckg/Core/Elements/TextResponseElement.php
+++ b/src/Convo/Pckg/Core/Elements/TextResponseElement.php
@@ -69,7 +69,7 @@ class TextResponseElement extends \Convo\Core\Workflow\AbstractWorkflowComponent
 	// UTIL
 	public function __toString()
 	{
-		return parent::__toString().'['.$this->evaluateString($this->_type).']['.$this->_break.']['.$this->_text.']';
+		return parent::__toString().'['.$this->_type.']['.$this->_break.']['.$this->_text.']';
 	}
 
     private function _addPlatformText($response, $text, $type): void

--- a/tests/unit/Convo/Core/ConvoServiceInstanceTest.php
+++ b/tests/unit/Convo/Core/ConvoServiceInstanceTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+use Convo\Core\Admin\AdminUser;
+use Convo\Core\ConvoServiceInstance;
+use Convo\Core\Expression\EvaluationContext;
+use Convo\Core\Expression\ExpressionFunctionProviderInterface;
+use Convo\Core\Factory\ConvoServiceFactory;
+use Convo\Core\Params\IServiceParamsFactory;
+use Convo\Core\Util\EchoLogger;
+use Convo\Pckg\Core\Elements\LoopElement;
+use Convo\Pckg\Core\Elements\TextResponseElement;
+use PHPUnit\Framework\TestCase;
+
+class ConvoServiceInstanceTest extends TestCase
+{
+    private $_logger;
+
+    private $_evaluationContext;
+
+    public function setUp(): void
+    {
+        $this->_logger = new EchoLogger();
+        $this->_evaluationContext = $this->_evalContext = new EvaluationContext(
+            $this->_logger,
+            new class implements ExpressionFunctionProviderInterface {
+                public function getFunctions()
+                {
+                    return [];
+                }
+            }
+        );
+    }
+
+    public function testParentChildRelations()
+    {
+        $service = new ConvoServiceInstance(
+            $this->_logger,
+            $this->_evaluationContext,
+            new class () implements IServiceParamsFactory
+            {
+                public function getServiceParams( \Convo\Core\Params\IServiceParamsScope $scope)
+                {
+                    return null;
+                }
+            },
+            new AdminUser('', '', '', ''),
+            'test'
+        );
+
+        $text_response = new TextResponseElement([
+            '_component_id' => ConvoServiceFactory::generateId()
+        ]);
+        $service->addChild($text_response); // should get overwritten
+
+        $for_loop = new LoopElement([
+            '_component_id' => ConvoServiceFactory::generateId(),
+            'data_collection' => '${[]}',
+            'item' => 'item',
+            'loop_until' => null, 'offset' => null, 'limit' => null,
+            'elements' => [$text_response]
+        ]);
+        $service->addChild($for_loop);
+
+        $this->assertEquals(1, count($service->getChildren()), 'Service must have exactly 1 child.');
+        $this->assertEquals(LoopElement::class, get_class($service->getChildren()[0]), 'Service\'s child must be ['.LoopElement::class.']');
+
+        $this->assertEquals(1, count($for_loop->getChildren()), 'For Loop must have exactly 1 child.');
+        $this->assertEquals(TextResponseElement::class, get_class($for_loop->getChildren()[0]), 'For Loop\'s child must be ['.TextResponseElement::class.']');
+    }
+}


### PR DESCRIPTION
* Extended `IWorkflowContainerComponent` with a new method -- `removeChild`
* Implemented new method in `AbstractWorkflowContainerComponent` and `ConvoServiceInstance`
  * When adding a child, check to see if it has a set parent already and that the parent is not `$this`
  * If so, remove the child from the parent before setting new one